### PR TITLE
Small optimization change

### DIFF
--- a/Assets/Scripts/PoolManager.cs
+++ b/Assets/Scripts/PoolManager.cs
@@ -55,8 +55,7 @@ public class PoolManager : Singleton<PoolManager>
 		var pool = prefabLookup[prefab];
 
 		var clone = pool.GetItem();
-		clone.transform.position = position;
-		clone.transform.rotation = rotation;
+        clone.transform.SetPositionAndRotation(position, rotation);
 		clone.SetActive(true);
 
 		instanceLookup.Add(clone, pool);

--- a/Assets/Scripts/PoolManager.cs
+++ b/Assets/Scripts/PoolManager.cs
@@ -55,7 +55,7 @@ public class PoolManager : Singleton<PoolManager>
 		var pool = prefabLookup[prefab];
 
 		var clone = pool.GetItem();
-        clone.transform.SetPositionAndRotation(position, rotation);
+		clone.transform.SetPositionAndRotation(position, rotation);
 		clone.SetActive(true);
 
 		instanceLookup.Add(clone, pool);


### PR DESCRIPTION
Use the more performant `transforn.SetPositionAndRotation` insted of individual calls.

Hey great repo, I checked different object pooling ones and yours was my favorite. 
While reading your code I just found a little optimization trick that can be applied.

Instead of the individual `transform.position = position` and `transform.rotation = rotation`, you could use `transform.SetPositionAndRotation(position, rotation)` to get an small performance boost.

I know it may be like a really small improvement, but because it is an object pool which intention is to be optimized, I think it can be helpful:)